### PR TITLE
feat: Add Layarkaca provider and update repository configuration

### DIFF
--- a/Layarkaca/build.gradle.kts
+++ b/Layarkaca/build.gradle.kts
@@ -1,0 +1,24 @@
+// use an integer for version numbers
+version = 1
+
+cloudstream {
+    language = "id"
+    // All of these properties are optional, you can safely remove them
+    authors = listOf("Aviv B.A")
+
+    /**
+     * Status int as the following:
+     * 0: Down
+     * 1: Ok
+     * 2: Slow
+     * 3: Beta only
+     * */
+    status = 1 // will be 3 if unspecified
+    tvTypes = listOf(
+        "Movie",
+        "TvSeries",
+        "AsianDrama"
+    )
+
+    iconUrl = "https://www.google.com/s2/favicons?domain=lk21official.cc&sz=%size%"
+}

--- a/Layarkaca/src/main/AndroidManifest.xml
+++ b/Layarkaca/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/Layarkaca/src/main/kotlin/com/avivba/Extractors.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/Extractors.kt
@@ -1,0 +1,86 @@
+package com.avivba
+
+import com.lagradost.cloudstream3.SubtitleFile
+import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.extractors.Filesim
+import com.lagradost.cloudstream3.utils.ExtractorApi
+import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.INFER_TYPE
+import com.lagradost.cloudstream3.utils.M3u8Helper
+import com.lagradost.cloudstream3.utils.getQualityFromName
+
+open class Emturbovid : ExtractorApi() {
+    override val name = "Emturbovid"
+    override val mainUrl = "https://emturbovid.com"
+    override val requiresReferer = true
+
+    override suspend fun getUrl(
+            url: String,
+            referer: String?,
+            subtitleCallback: (SubtitleFile) -> Unit,
+            callback: (ExtractorLink) -> Unit
+    ) {
+        val response = app.get(url, referer = referer)
+        val m3u8 = Regex("[\"'](.*?master\\.m3u8.*?)[\"']").find(response.text)?.groupValues?.getOrNull(1)
+        M3u8Helper.generateM3u8(
+                name,
+                m3u8 ?: return,
+                mainUrl
+        ).forEach(callback)
+    }
+
+}
+
+open class Hownetwork : ExtractorApi() {
+    override val name = "Hownetwork"
+    override val mainUrl = "https://stream.hownetwork.xyz"
+    override val requiresReferer = true
+
+    override suspend fun getUrl(
+            url: String,
+            referer: String?,
+            subtitleCallback: (SubtitleFile) -> Unit,
+            callback: (ExtractorLink) -> Unit
+    ) {
+        val id = url.substringAfter("id=")
+        val res = app.post(
+                "$mainUrl/api.php?id=$id",
+                data = mapOf(
+                        "r" to "https://playeriframe.shop/",
+                        "d" to "stream.hownetwork.xyz",
+                ),
+                referer = url,
+                headers = mapOf(
+                        "X-Requested-With" to "XMLHttpRequest"
+                )
+        ).parsedSafe<Sources>()
+
+        res?.data?.map {
+            callback.invoke(
+                    ExtractorLink(
+                            this.name,
+                            this.name,
+                            it.file,
+                            url,
+                            getQualityFromName(it.label),
+                            INFER_TYPE
+                    )
+            )
+        }
+
+    }
+
+    data class Sources(
+            val data: ArrayList<Data>
+    ) {
+        data class Data(
+                val file: String,
+                val label: String?,
+        )
+    }
+}
+
+class Furher : Filesim() {
+    override val name = "Furher"
+    override var mainUrl = "https://furher.in"
+}

--- a/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
@@ -1,0 +1,177 @@
+package com.avivba
+
+import com.lagradost.cloudstream3.*
+import com.lagradost.cloudstream3.LoadResponse.Companion.addActors
+import com.lagradost.cloudstream3.LoadResponse.Companion.addTrailer
+import com.lagradost.cloudstream3.extractors.Filesim
+import com.lagradost.cloudstream3.utils.*
+import org.jsoup.nodes.Element
+
+class LayarKacaProvider : MainAPI() {
+
+    override var mainUrl = "https://tv6.lk21official.cc"
+    private var seriesUrl = "https://tv1.nontondrama.my"
+
+    override var name = "LayarKaca"
+    override val hasMainPage = true
+    override var lang = "id"
+    override val supportedTypes = setOf(
+            TvType.Movie,
+            TvType.TvSeries,
+            TvType.AsianDrama
+    )
+
+    override val mainPage = mainPageOf(
+            "$mainUrl/populer/page/" to "Film Terplopuler",
+            "$mainUrl/rating/page/" to "Film Berdasarkan IMDb Rating",
+            "$mainUrl/most-commented/page/" to "Film Dengan Komentar Terbanyak",
+            "$seriesUrl/latest-series/page/" to "Series Terbaru",
+            "$seriesUrl/series/asian/page/" to "Film Asian Terbaru",
+            "$mainUrl/latest/page/" to "Film Upload Terbaru",
+    )
+
+    override suspend fun getMainPage(
+            page: Int,
+            request: MainPageRequest
+    ): HomePageResponse {
+        val document = app.get(request.data + page).document
+        val home = document.select("article.mega-item").mapNotNull {
+            it.toSearchResult()
+        }
+        return newHomePageResponse(request.name, home)
+    }
+
+    private suspend fun getProperLink(url: String): String? {
+        if(url.startsWith(seriesUrl)) return url
+        val res = app.get(url).document
+        return if (res.select("title").text().contains("- Nontondrama", true)) {
+            res.selectFirst("div#content a")?.attr("href")
+        } else {
+            url
+        }
+    }
+
+    private fun Element.toSearchResult(): SearchResponse? {
+        val title = this.selectFirst("h1.grid-title > a")?.ownText()?.trim() ?: return null
+        val href = fixUrl(this.selectFirst("a")!!.attr("href"))
+        val posterUrl = fixUrlNull(this.selectFirst("img")?.attr("src"))
+        val type =
+                if (this.selectFirst("div.last-episode") == null) TvType.Movie else TvType.TvSeries
+        return if (type == TvType.TvSeries) {
+            val episode = this.selectFirst("div.last-episode span")?.text()?.filter { it.isDigit() }
+                    ?.toIntOrNull()
+            newAnimeSearchResponse(title, href, TvType.TvSeries) {
+                this.posterUrl = posterUrl
+                addSub(episode)
+            }
+        } else {
+            val quality = this.select("div.quality").text().trim()
+            newMovieSearchResponse(title, href, TvType.Movie) {
+                this.posterUrl = posterUrl
+                addQuality(quality)
+            }
+        }
+    }
+
+    override suspend fun search(query: String): List<SearchResponse> {
+        val document = app.get("$mainUrl/search.php?s=$query").document
+        return document.select("div.search-item").mapNotNull {
+            val title = it.selectFirst("a")?.attr("title") ?: ""
+            val href = fixUrl(it.selectFirst("a")?.attr("href") ?: return@mapNotNull null)
+            val posterUrl = fixUrlNull(it.selectFirst("img.img-thumbnail")?.attr("src"))
+            newTvSeriesSearchResponse(title, href, TvType.TvSeries) {
+                this.posterUrl = posterUrl
+            }
+        }
+    }
+
+    override suspend fun load(url: String): LoadResponse? {
+        val fixUrl = getProperLink(url)
+        val document = app.get(fixUrl ?: return null).document
+
+        val title = document.selectFirst("li.last > span[itemprop=name]")?.text()?.trim().toString()
+        val poster = fixUrl(document.select("img.img-thumbnail").attr("src").toString())
+        val tags = document.select("div.content > div:nth-child(5) > h3 > a").map { it.text() }
+
+        val year = Regex("\\d, (\\d+)").find(
+                document.select("div.content > div:nth-child(7) > h3").text().trim()
+        )?.groupValues?.get(1).toString().toIntOrNull()
+        val tvType = if (document.select("div.serial-wrapper")
+                        .isNotEmpty()
+        ) TvType.TvSeries else TvType.Movie
+        val description = document.select("div.content > blockquote").text().trim()
+        val trailer = document.selectFirst("div.action-player li > a.fancybox")?.attr("href")
+        val rating =
+                document.selectFirst("div.content > div:nth-child(6) > h3")?.text()?.toRatingInt()
+        val actors =
+                document.select("div.col-xs-9.content > div:nth-child(3) > h3 > a").map { it.text() }
+
+        val recommendations = document.select("div.row.item-media").map {
+            val recName = it.selectFirst("h3")?.text()?.trim().toString()
+            val recHref = it.selectFirst(".content-media > a")!!.attr("href")
+            val recPosterUrl =
+                    fixUrl(it.selectFirst(".poster-media > a > img")?.attr("src").toString())
+            newTvSeriesSearchResponse(recName, recHref, TvType.TvSeries) {
+                this.posterUrl = recPosterUrl
+            }
+        }
+
+        return if (tvType == TvType.TvSeries) {
+            val episodes = document.select("div.episode-list > a:matches(\\d+)").map {
+                val href = fixUrl(it.attr("href"))
+                val episode = it.text().toIntOrNull()
+                val season =
+                        it.attr("href").substringAfter("season-").substringBefore("-").toIntOrNull()
+                Episode(
+                        href,
+                        "Episode $episode",
+                        season,
+                        episode,
+                )
+            }.reversed()
+            newTvSeriesLoadResponse(title, url, TvType.TvSeries, episodes) {
+                this.posterUrl = poster
+                this.year = year
+                this.plot = description
+                this.tags = tags
+                this.rating = rating
+                addActors(actors)
+                this.recommendations = recommendations
+                addTrailer(trailer)
+            }
+        } else {
+            newMovieLoadResponse(title, url, TvType.Movie, url) {
+                this.posterUrl = poster
+                this.year = year
+                this.plot = description
+                this.tags = tags
+                this.rating = rating
+                addActors(actors)
+                this.recommendations = recommendations
+                addTrailer(trailer)
+            }
+        }
+    }
+
+    override suspend fun loadLinks(
+            data: String,
+            isCasting: Boolean,
+            subtitleCallback: (SubtitleFile) -> Unit,
+            callback: (ExtractorLink) -> Unit
+    ): Boolean {
+
+        val document = app.get(data).document
+        document.select("ul#loadProviders > li").map {
+            fixUrl(it.select("a").attr("href"))
+        }.apmap {
+            loadExtractor(it.getIframe(), "https://nganunganu.sbs", subtitleCallback, callback)
+        }
+
+        return true
+    }
+
+    private suspend fun String.getIframe() : String {
+        return app.get(this, referer = "$seriesUrl/").document.select("div.embed iframe").attr("src")
+    }
+
+}

--- a/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProviderPlugin.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProviderPlugin.kt
@@ -1,0 +1,16 @@
+package com.avivba
+
+import com.lagradost.cloudstream3.plugins.CloudstreamPlugin
+import com.lagradost.cloudstream3.plugins.Plugin
+import android.content.Context
+
+@CloudstreamPlugin
+class LayarKacaProviderPlugin: Plugin() {
+    override fun load(context: Context) {
+        // All providers should be added in this manner. Please don't edit the providers list directly.
+        registerMainAPI(LayarKacaProvider())
+        registerExtractorAPI(Emturbovid())
+        registerExtractorAPI(Furher())
+        registerExtractorAPI(Hownetwork())
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ subprojects {
 
     cloudstream {
         // when running through github workflow, GITHUB_REPOSITORY should contain current repository name
-        setRepo("https://github.com/avivbintangaringga/cloudstream-extensions")
+        setRepo("https://github.com/${System.getenv("GITHUB_REPOSITORY") ?: "psionicdrevus/imsh"}")
         authors = listOf("Aviv B.A")
     }
 

--- a/repo.json
+++ b/repo.json
@@ -3,6 +3,6 @@
     "description": "Indonesian provider",
     "manifestVersion": 1,
     "pluginLists": [
-      "https://raw.githubusercontent.com/avivbintangaringga/cloudstream-extensions/builds/plugins.json"
+      "https://raw.githubusercontent.com/psionicdrevus/imsh/builds/plugins.json"
     ]
   }


### PR DESCRIPTION
This commit introduces the new `Layarkaca` provider, which scrapes movies and TV series from the Layarkaca website. The provider is created by mirroring the structure of the existing `Ngefilm` provider.

The new provider includes:
- Main provider logic in `LayarKacaProvider.kt`.
- Extractors for various video hosts in `Extractors.kt`.
- A plugin entry point in `LayarKacaProviderPlugin.kt`.
- Build and manifest files.

Additionally, this commit updates the repository configuration to point to the new user's GitHub repository.
- `repo.json` is updated with the new `plugins.json` URL.
- `build.gradle.kts` is updated to dynamically use the `GITHUB_REPOSITORY` environment variable, ensuring correct plugin URL generation during the build process.