### PR TITLE
feat: Update extractors for LayarKaca

### DIFF
--- a/Layarkaca/src/main/kotlin/com/avivba/Extractors.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/Extractors.kt
@@ -9,29 +9,111 @@ import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.M3u8Helper
 import com.lagradost.cloudstream3.utils.getQualityFromName
 
+// --- Emturbovid extractor ---
 open class Emturbovid : ExtractorApi() {
     override val name = "Emturbovid"
     override val mainUrl = "https://emturbovid.com"
     override val requiresReferer = true
 
     override suspend fun getUrl(
-            url: String,
-            referer: String?,
-            subtitleCallback: (SubtitleFile) -> Unit,
-            callback: (ExtractorLink) -> Unit
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
     ) {
         val response = app.get(url, referer = referer)
-        val m3u8 = Regex("[\"'](.*?master\\.m3u8.*?)[\"']").find(response.text)?.groupValues?.getOrNull(1)
+        val m3u8 = Regex("[\"'](.*?master\\.m3u8.*?)[\"']")
+            .find(response.text)
+            ?.groupValues?.getOrNull(1)
+            ?: return
+
         M3u8Helper.generateM3u8(
-                name,
-                m3u8 ?: return,
-                mainUrl
+            name,
+            m3u8,
+            mainUrl
         ).forEach(callback)
     }
-
 }
 
 class Furher : Filesim() {
     override val name = "Furher"
     override var mainUrl = "https://furher.in"
+}
+
+// --- Filemoon extractor ---
+open class FilemoonExtractor : ExtractorApi() {
+    override val name = "Filemoon"
+    override val mainUrl = "https://filemoon.sx"
+    override val requiresReferer = true
+
+    override suspend fun getUrl(
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
+    ) {
+        val response = app.get(url, referer = referer)
+        val m3u8 = Regex("[\"'](.*?\\.m3u8.*?)[\"']")
+            .find(response.text)
+            ?.groupValues?.getOrNull(1)
+            ?: return
+
+        M3u8Helper.generateM3u8(
+            name,
+            m3u8,
+            mainUrl
+        ).forEach(callback)
+    }
+}
+
+// --- Hydrax extractor (short.icu) ---
+open class HydraxExtractor : ExtractorApi() {
+    override val name = "Hydrax"
+    override val mainUrl = "https://short.icu"
+    override val requiresReferer = true
+
+    override suspend fun getUrl(
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
+    ) {
+        val response = app.get(url, referer = referer)
+        val m3u8 = Regex("[\"'](.*?\\.m3u8.*?)[\"']")
+            .find(response.text)
+            ?.groupValues?.getOrNull(1)
+            ?: return
+
+        M3u8Helper.generateM3u8(
+            name,
+            m3u8,
+            mainUrl
+        ).forEach(callback)
+    }
+}
+
+// --- HowNetwork extractor (P2P) ---
+open class HowNetworkExtractor : ExtractorApi() {
+    override val name = "HowNetwork"
+    override val mainUrl = "https://cloud.hownetwork.xyz"
+    override val requiresReferer = true
+
+    override suspend fun getUrl(
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
+    ) {
+        val response = app.get(url, referer = referer)
+        val m3u8 = Regex("[\"'](.*?\\.m3u8.*?)[\"']")
+            .find(response.text)
+            ?.groupValues?.getOrNull(1)
+            ?: return
+
+        M3u8Helper.generateM3u8(
+            name,
+            m3u8,
+            mainUrl
+        ).forEach(callback)
+    }
 }

--- a/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
@@ -172,7 +172,23 @@ class LayarKacaProvider : MainAPI() {
         val document = app.get(data).document
         document.select("li > a[data-url]").apmap {
             val url = it.attr("data-url")
-            loadExtractor(url, data, subtitleCallback, callback)
+            when {
+                "emturbovid.com" in url -> {
+                    Emturbovid().getUrl(url, data, subtitleCallback, callback)
+                }
+                "filemoon.sx" in url -> {
+                    FilemoonExtractor().getUrl(url, data, subtitleCallback, callback)
+                }
+                "short.icu" in url -> {
+                    HydraxExtractor().getUrl(url, data, subtitleCallback, callback)
+                }
+                "hownetwork.xyz" in url -> {
+                    HowNetworkExtractor().getUrl(url, data, subtitleCallback, callback)
+                }
+                else -> {
+                    loadExtractor(url, data, subtitleCallback, callback)
+                }
+            }
         }
         return true
     }


### PR DESCRIPTION
This commit updates the video server extractors for the LayarKaca provider based on user feedback.

- The regex for finding m3u8 links has been improved to be more generic.
- The null handling in the extractors has been made more concise using the elvis operator.
- All four extractors (Emturbovid, Filemoon, Hydrax, HowNetwork) now use the same improved patterns.