### PR TITLE
Fix build errors in Layarkaca and Ngefilm modules

### DIFF
--- a/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProvider.kt
@@ -124,7 +124,7 @@ class LayarKacaProvider : MainAPI() {
                 this.year = year
                 this.plot = description
                 this.tags = tags
-                this.score = rating
+                this.score = rating?.toDouble()
                 addActors(actors)
                 this.recommendations = recommendations
             }
@@ -158,7 +158,7 @@ class LayarKacaProvider : MainAPI() {
                 this.year = year
                 this.plot = description
                 this.tags = tags
-                this.score = rating
+                this.score = rating?.toDouble()
                 addActors(actors)
                 this.recommendations = recommendations
             }
@@ -181,13 +181,16 @@ class LayarKacaProvider : MainAPI() {
                             Emturbovid().getUrl(url, data, subtitleCallback, callback)
                         }
                         "filemoon.sx" in url -> {
-                            FilemoonExtractor().getUrl(url, data, subtitleCallback, callback)
+                            Filemoon().getUrl(url, data, subtitleCallback, callback)
                         }
                         "short.icu" in url -> {
-                            HydraxExtractor().getUrl(url, data, subtitleCallback, callback)
+                            Hydrax().getUrl(url, data, subtitleCallback, callback)
                         }
                         "hownetwork.xyz" in url -> {
-                            HowNetworkExtractor().getUrl(url, data, subtitleCallback, callback)
+                            HowNetwork().getUrl(url, data, subtitleCallback, callback)
+                        }
+                        "furher.in" in url -> {
+                            Furher().getUrl(url, data, subtitleCallback, callback)
                         }
                         else -> {
                             loadExtractor(url, data, subtitleCallback, callback)

--- a/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProviderPlugin.kt
+++ b/Layarkaca/src/main/kotlin/com/avivba/LayarKacaProviderPlugin.kt
@@ -10,6 +10,9 @@ class LayarKacaProviderPlugin: Plugin() {
         // All providers should be added in this manner. Please don't edit the providers list directly.
         registerMainAPI(LayarKacaProvider())
         registerExtractorAPI(Emturbovid())
+        registerExtractorAPI(Filemoon())
+        registerExtractorAPI(Hydrax())
+        registerExtractorAPI(HowNetwork())
         registerExtractorAPI(Furher())
     }
 }

--- a/Ngefilm/src/main/kotlin/com/avivba/Ngefilm.kt
+++ b/Ngefilm/src/main/kotlin/com/avivba/Ngefilm.kt
@@ -128,7 +128,7 @@ open class Ngefilm : MainAPI() {
                 this.year = year
                 this.plot = description
                 this.tags = tags
-                this.score = rating
+                this.score = rating?.toDouble()
                 addActors(actors)
                 this.recommendations = recommendations
                 addTrailer(trailer)
@@ -140,7 +140,7 @@ open class Ngefilm : MainAPI() {
                 this.year = year
                 this.plot = description
                 this.tags = tags
-                this.score = rating
+                this.score = rating?.toDouble()
                 addActors(actors)
                 this.recommendations = recommendations
                 addTrailer(trailer)


### PR DESCRIPTION
This commit applies several fixes to resolve build errors, based on the user's detailed instructions.

- Fixed `Int?` to `Score?` type mismatch by converting the rating to a Double in `LayarKacaProvider.kt` and `Ngefilm.kt`.
- Updated extractor class names in `LayarKacaProvider.kt` to match the ones defined in `Extractors.kt`.
- Added `Furher` extractor to the `when` block in `loadLinks` in `LayarKacaProvider.kt`.
- Registered all new extractors (`Emturbovid`, `Filemoon`, `Hydrax`, `HowNetwork`, `Furher`) in `LayarKacaProviderPlugin.kt`.